### PR TITLE
cpp: export operators for isl::val, isl::aff, and isl::pw_aff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: c
+
+compiler:
+        - clang
+        - gcc
+
+os:
+        - linux
+#        - osx
+
+osx_image: xcode9
+
+dist: trusty
+
+before_install:
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gmp     ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --with-clang --with-lld --with-python llvm ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libgmp-dev libedit-dev ; fi
+        - export PATH=/usr/local/opt/llvm/bin:$PATH
+        - git submodule init
+        - git submodule update
+env:
+        - INT=gmp
+        - INT=imath
+        - INT=imath-32
+
+script:
+        - ./autogen.sh && ./configure --with-int=$INT --with-clang=system && make && make check

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -73,6 +73,7 @@ __isl_give isl_aff *isl_aff_set_dim_id(__isl_take isl_aff *aff,
 int isl_aff_find_dim_by_name(__isl_keep isl_aff *aff, enum isl_dim_type type,
 	const char *name);
 
+__isl_export
 isl_bool isl_aff_plain_is_equal(__isl_keep isl_aff *aff1,
 	__isl_keep isl_aff *aff2);
 isl_bool isl_aff_plain_is_zero(__isl_keep isl_aff *aff);
@@ -201,6 +202,7 @@ isl_bool isl_pw_aff_is_empty(__isl_keep isl_pw_aff *pwaff);
 isl_bool isl_pw_aff_involves_nan(__isl_keep isl_pw_aff *pa);
 int isl_pw_aff_plain_cmp(__isl_keep isl_pw_aff *pa1,
 	__isl_keep isl_pw_aff *pa2);
+__isl_export
 isl_bool isl_pw_aff_plain_is_equal(__isl_keep isl_pw_aff *pwaff1,
 	__isl_keep isl_pw_aff *pwaff2);
 isl_bool isl_pw_aff_is_equal(__isl_keep isl_pw_aff *pa1,

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -81,7 +81,7 @@ isl_bool isl_aff_is_nan(__isl_keep isl_aff *aff);
 
 __isl_give isl_aff *isl_aff_get_div(__isl_keep isl_aff *aff, int pos);
 
-__isl_export
+__isl_operator
 __isl_give isl_aff *isl_aff_neg(__isl_take isl_aff *aff);
 __isl_export
 __isl_give isl_aff *isl_aff_ceil(__isl_take isl_aff *aff);
@@ -91,16 +91,16 @@ __isl_overload
 __isl_give isl_aff *isl_aff_mod_val(__isl_take isl_aff *aff,
 	__isl_take isl_val *mod);
 
-__isl_export
+__isl_operator
 __isl_give isl_aff *isl_aff_mul(__isl_take isl_aff *aff1,
 	__isl_take isl_aff *aff2);
-__isl_export
+__isl_operator
 __isl_give isl_aff *isl_aff_div(__isl_take isl_aff *aff1,
 	__isl_take isl_aff *aff2);
-__isl_export
+__isl_operator
 __isl_give isl_aff *isl_aff_add(__isl_take isl_aff *aff1,
 	__isl_take isl_aff *aff2);
-__isl_export
+__isl_operator
 __isl_give isl_aff *isl_aff_sub(__isl_take isl_aff *aff1,
 	__isl_take isl_aff *aff2);
 

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -251,19 +251,19 @@ __isl_give isl_pw_aff *isl_pw_aff_min(__isl_take isl_pw_aff *pwaff1,
 __isl_export
 __isl_give isl_pw_aff *isl_pw_aff_max(__isl_take isl_pw_aff *pwaff1,
 	__isl_take isl_pw_aff *pwaff2);
-__isl_export
+__isl_operator
 __isl_give isl_pw_aff *isl_pw_aff_mul(__isl_take isl_pw_aff *pwaff1,
 	__isl_take isl_pw_aff *pwaff2);
-__isl_export
+__isl_operator
 __isl_give isl_pw_aff *isl_pw_aff_div(__isl_take isl_pw_aff *pa1,
 	__isl_take isl_pw_aff *pa2);
-__isl_export
+__isl_operator
 __isl_give isl_pw_aff *isl_pw_aff_add(__isl_take isl_pw_aff *pwaff1,
 	__isl_take isl_pw_aff *pwaff2);
-__isl_export
+__isl_operator
 __isl_give isl_pw_aff *isl_pw_aff_sub(__isl_take isl_pw_aff *pwaff1,
 	__isl_take isl_pw_aff *pwaff2);
-__isl_export
+__isl_operator
 __isl_give isl_pw_aff *isl_pw_aff_neg(__isl_take isl_pw_aff *pwaff);
 __isl_export
 __isl_give isl_pw_aff *isl_pw_aff_ceil(__isl_take isl_pw_aff *pwaff);

--- a/include/isl/ctx.h
+++ b/include/isl/ctx.h
@@ -33,6 +33,9 @@
 #ifndef __isl_overload
 #define __isl_overload
 #endif
+#ifndef __isl_operator
+#define __isl_operator
+#endif
 #ifndef __isl_constructor
 #define __isl_constructor
 #endif

--- a/include/isl/val.h
+++ b/include/isl/val.h
@@ -58,7 +58,7 @@ __isl_give isl_val *isl_val_set_si(__isl_take isl_val *v, long i);
 
 __isl_export
 __isl_give isl_val *isl_val_abs(__isl_take isl_val *v);
-__isl_export
+__isl_operator
 __isl_give isl_val *isl_val_neg(__isl_take isl_val *v);
 __isl_export
 __isl_give isl_val *isl_val_inv(__isl_take isl_val *v);
@@ -73,16 +73,16 @@ __isl_export
 __isl_give isl_val *isl_val_min(__isl_take isl_val *v1, __isl_take isl_val *v2);
 __isl_export
 __isl_give isl_val *isl_val_max(__isl_take isl_val *v1, __isl_take isl_val *v2);
-__isl_export
+__isl_operator
 __isl_give isl_val *isl_val_add(__isl_take isl_val *v1, __isl_take isl_val *v2);
 __isl_give isl_val *isl_val_add_ui(__isl_take isl_val *v1, unsigned long v2);
-__isl_export
+__isl_operator
 __isl_give isl_val *isl_val_sub(__isl_take isl_val *v1, __isl_take isl_val *v2);
 __isl_give isl_val *isl_val_sub_ui(__isl_take isl_val *v1, unsigned long v2);
-__isl_export
+__isl_operator
 __isl_give isl_val *isl_val_mul(__isl_take isl_val *v1, __isl_take isl_val *v2);
 __isl_give isl_val *isl_val_mul_ui(__isl_take isl_val *v1, unsigned long v2);
-__isl_export
+__isl_operator
 __isl_give isl_val *isl_val_div(__isl_take isl_val *v1, __isl_take isl_val *v2);
 __isl_give isl_val *isl_val_div_ui(__isl_take isl_val *v1, unsigned long v2);
 __isl_export
@@ -122,17 +122,17 @@ isl_bool isl_val_is_neginfty(__isl_keep isl_val *v);
 __isl_export
 int isl_val_cmp_si(__isl_keep isl_val *v, long i);
 
-__isl_export
+__isl_operator
 isl_bool isl_val_lt(__isl_keep isl_val *v1, __isl_keep isl_val *v2);
-__isl_export
+__isl_operator
 isl_bool isl_val_le(__isl_keep isl_val *v1, __isl_keep isl_val *v2);
-__isl_export
+__isl_operator
 isl_bool isl_val_gt(__isl_keep isl_val *v1, __isl_keep isl_val *v2);
-__isl_export
+__isl_operator
 isl_bool isl_val_ge(__isl_keep isl_val *v1, __isl_keep isl_val *v2);
-__isl_export
+__isl_operator
 isl_bool isl_val_eq(__isl_keep isl_val *v1, __isl_keep isl_val *v2);
-__isl_export
+__isl_operator
 isl_bool isl_val_ne(__isl_keep isl_val *v1, __isl_keep isl_val *v2);
 __isl_export
 isl_bool isl_val_abs_eq(__isl_keep isl_val *v1, __isl_keep isl_val *v2);

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -14,6 +14,7 @@ public:
 		function_kind_static_method,
 		function_kind_member_method,
 		function_kind_constructor,
+		function_kind_operator,
 	};
 
 	virtual void generate();
@@ -71,4 +72,5 @@ private:
 	bool is_subclass(QualType subclass_type, const isl_class &class_type);
 	function_kind get_method_kind(const isl_class &clazz,
 		FunctionDecl *method);
+	std::string get_op_name(std::string name);
 };

--- a/interface/extract_interface.cc
+++ b/interface/extract_interface.cc
@@ -426,6 +426,9 @@ int main(int argc, char *argv[])
 	PO.addMacroDef("__isl_overload="
 	    "__attribute__((annotate(\"isl_overload\"))) "
 	    "__attribute__((annotate(\"isl_export\")))");
+	PO.addMacroDef("__isl_operator="
+	    "__attribute__((annotate(\"isl_operator\"))) "
+	    "__attribute__((annotate(\"isl_export\")))");
 	PO.addMacroDef("__isl_constructor=__attribute__((annotate(\"isl_constructor\"))) __attribute__((annotate(\"isl_export\")))");
 	PO.addMacroDef("__isl_subclass(super)=__attribute__((annotate(\"isl_subclass(\" #super \")\"))) __attribute__((annotate(\"isl_export\")))");
 

--- a/interface/generator.cc
+++ b/interface/generator.cc
@@ -160,6 +160,13 @@ std::vector<string> generator::find_superclasses(RecordDecl *decl)
 	return super;
 }
 
+/* Is decl marked as operator?
+ */
+bool generator::is_operator(Decl *decl)
+{
+	return has_annotation(decl, "isl_operator");
+}
+
 /* Is decl marked as being part of an overloaded method?
  */
 bool generator::is_overload(Decl *decl)

--- a/interface/generator.h
+++ b/interface/generator.h
@@ -51,6 +51,7 @@ protected:
 	void die(string msg) __attribute__((noreturn));
 	vector<string> find_superclasses(RecordDecl *decl);
 	bool is_overload(Decl *decl);
+	bool is_operator(Decl *decl);
 	bool is_constructor(Decl *decl);
 	bool takes(Decl *decl);
 	bool keeps(Decl *decl);

--- a/interface/isl_test_cpp.cpp
+++ b/interface/isl_test_cpp.cpp
@@ -366,6 +366,31 @@ void test_operators_aff(isl::ctx ctx)
 	assert((four / two).plain_is_equal(two));
 }
 
+/* Test C++ operators for isl_pw_aff
+ *
+ * This includes:
+ *
+ * # Arithmetic
+ *  - negation
+ *  - addition / subtraction
+ *  - multiplication / division
+ */
+void test_operators_pw_aff(isl::ctx ctx)
+{
+	isl::pw_aff i(ctx, "{ [i] -> [i] }");
+	isl::pw_aff zero(ctx, "{ [i] -> [0] }");
+	isl::pw_aff one(ctx, "{ [i] -> [1] }");
+	isl::pw_aff neg_one(ctx, "{ [i] -> [-1] }");
+	isl::pw_aff two(ctx, "{ [i] -> [2] }");
+	isl::pw_aff four(ctx, "{ [i] -> [4] }");
+
+	assert((-one).plain_is_equal(neg_one));
+	assert((zero + one).plain_is_equal(one));
+	assert((zero - one).plain_is_equal(neg_one));
+	assert((zero * one).plain_is_equal(zero));
+	assert((four / two).plain_is_equal(two));
+}
+
 /* Test C++ operators for:
  *
  * - isl_val
@@ -375,6 +400,7 @@ void test_operators(isl::ctx ctx)
 {
 	test_operators_val(ctx);
 	test_operators_aff(ctx);
+	test_operators_pw_aff(ctx);
 }
 
 /* Test the isl C++ interface

--- a/interface/isl_test_cpp.cpp
+++ b/interface/isl_test_cpp.cpp
@@ -341,13 +341,40 @@ void test_operators_val(isl::ctx ctx)
 	assert(one != two);
 }
 
+/* Test C++ operators for isl_aff
+ *
+ * This includes:
+ *
+ * # Arithmetic
+ *  - negation
+ *  - addition / subtraction
+ *  - multiplication / division
+ */
+void test_operators_aff(isl::ctx ctx)
+{
+	isl::aff i(ctx, "{ [i] -> [i] }");
+	isl::aff zero(ctx, "{ [i] -> [0] }");
+	isl::aff one(ctx, "{ [i] -> [1] }");
+	isl::aff neg_one(ctx, "{ [i] -> [-1] }");
+	isl::aff two(ctx, "{ [i] -> [2] }");
+	isl::aff four(ctx, "{ [i] -> [4] }");
+
+	assert((-one).plain_is_equal(neg_one));
+	assert((zero + one).plain_is_equal(one));
+	assert((zero - one).plain_is_equal(neg_one));
+	assert((zero * one).plain_is_equal(zero));
+	assert((four / two).plain_is_equal(two));
+}
+
 /* Test C++ operators for:
  *
  * - isl_val
+ * - isl_aff
  */
 void test_operators(isl::ctx ctx)
 {
 	test_operators_val(ctx);
+	test_operators_aff(ctx);
 }
 
 /* Test the isl C++ interface

--- a/interface/isl_test_cpp.cpp
+++ b/interface/isl_test_cpp.cpp
@@ -307,6 +307,49 @@ void test_foreach(isl::ctx ctx)
 	assert(ret2 == isl::stat::error);
 }
 
+/* Test C++ operators for isl_val
+ *
+ * This includes:
+ *
+ * # Arithmetic
+ *  - negation
+ *  - addition / subtraction
+ *  - multiplication / division
+ *
+ * # Comparison
+ *  - Inequality
+ *  - Equality
+ */
+void test_operators_val(isl::ctx ctx)
+{
+	isl::val half(ctx, "1/2");
+	isl::val one(ctx, "1");
+	isl::val neg_one(ctx, "-1");
+	isl::val two(ctx, "2");
+	isl::val four(ctx, "4");
+
+	assert(-one == neg_one);
+	assert(one + one == two);
+	assert(two - one == one);
+	assert(two * two == four);
+	assert(one / two == half);
+	assert(one < two);
+	assert(one <= two);
+	assert(two > one);
+	assert(two >= one);
+	assert(one == one);
+	assert(one != two);
+}
+
+/* Test C++ operators for:
+ *
+ * - isl_val
+ */
+void test_operators(isl::ctx ctx)
+{
+	test_operators_val(ctx);
+}
+
 /* Test the isl C++ interface
  *
  * This includes:
@@ -315,6 +358,7 @@ void test_foreach(isl::ctx ctx)
  *  - Different parameter types
  *  - Different return types
  *  - Foreach functions
+ *  - C++ operators
  */
 int main()
 {
@@ -325,6 +369,7 @@ int main()
 	test_parameters(ctx);
 	test_return(ctx);
 	test_foreach(ctx);
+	test_operators(ctx);
 
 	isl_ctx_free(ctx);
 }


### PR DESCRIPTION
Add operator overloads for isl::val, isl::aff, and isl::pw_aff. We currently only overload basic arithmetic functions and comparisons between values for which a direct mathematical correspondance exists and consequently confusion is unlikely. Here an example use for isl::val:

	isl::val half(ctx, "1/2");
	isl::val one(ctx, "1");
	isl::val neg_one(ctx, "-1");
	isl::val two(ctx, "2");
	isl::val four(ctx, "4");

	assert(-one == neg_one);
	assert(one + one == two);
	assert(two - one == one);
	assert(two * two == four);
	assert(one / two == half);
	assert(one < two);
	assert(one <= two);
	assert(two > one );
	assert(two >= one );
	assert(one == one);
	assert(one != two);

Signed-off-by: Tobias Grosser <tobias@grosser.es>