### PR TITLE
cpp: export space and the set and map empty and universe constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: c
+
+compiler:
+        - clang
+        - gcc
+
+os:
+        - linux
+
+# OSX builds do not work yet
+#        - osx
+
+osx_image: xcode9
+
+dist: trusty
+
+before_install:
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gmp     ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --with-clang --with-lld --with-python llvm ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libgmp-dev libedit-dev ; fi
+        - export PATH=/usr/local/opt/llvm/bin:$PATH
+        - git submodule init
+        - git submodule update
+env:
+        - INT=gmp
+        - INT=imath
+        - INT=imath-32
+
+script:
+        - ./autogen.sh && ./configure --with-int=$INT --with-clang=system && make && make check

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -941,6 +941,17 @@ parameters is discouraged.
 		unsigned nparam);
 	__isl_give isl_space *isl_space_set_alloc(isl_ctx *ctx,
 		unsigned nparam, unsigned dim);
+	__isl_give isl_space *isl_space_map_alloc_from_id_list(
+		__isl_take isl_id_list *param_ids,
+		unsigned n_in, unsigned n_out);
+	__isl_give isl_space *isl_space_set_alloc_from_id_list(
+		__isl_take isl_id_list *param_ids,
+		unsigned n_set);
+	__isl_give isl_space *isl_space_params_alloc_from_id_list(
+		__isl_take isl_id_list *param_ids);
+	__isl_give isl_space *isl_space_map_alloc_noparams(isl_ctx *ctx);
+	__isl_give isl_space *isl_space_set_alloc_noparams(isl_ctx *ctx);
+	__isl_give isl_space *isl_space_params_alloc_empty(isl_ctx *ctx);
 	__isl_give isl_space *isl_space_copy(__isl_keep isl_space *space);
 	__isl_null isl_space *isl_space_free(__isl_take isl_space *space);
 
@@ -949,7 +960,12 @@ needs to be created using C<isl_space_params_alloc>.
 For other sets, the space
 needs to be created using C<isl_space_set_alloc>, while
 for a relation, the space
-needs to be created using C<isl_space_alloc>.
+needs to be created using C<isl_space_alloc>. Spaces with named parameter
+dimensions can be directly constructed using
+C<isl_space_map_alloc_from_id_list>, C<isl_space_set_alloc_from_id_list>, or
+C<isl_space_params_alloc_from_id_list>. Spaces without any parameter dimensions
+can be conveniently constructed using C<isl_space_map_alloc_noparams>,
+C<isl_space_set_alloc_noparams>, C<isl_space_params_alloc_empty>.
 
 To check whether a given space is that of a set or a map
 or whether it is a parameter space, use these functions:

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -119,7 +119,9 @@ __isl_give isl_basic_map *isl_basic_map_less_at(__isl_take isl_space *dim,
 	unsigned pos);
 __isl_give isl_basic_map *isl_basic_map_more_at(__isl_take isl_space *dim,
 	unsigned pos);
+__isl_export
 __isl_give isl_basic_map *isl_basic_map_empty(__isl_take isl_space *space);
+__isl_export
 __isl_give isl_basic_map *isl_basic_map_universe(__isl_take isl_space *space);
 __isl_give isl_basic_map *isl_basic_map_nat_universe(__isl_take isl_space *dim);
 __isl_give isl_basic_map *isl_basic_map_remove_redundancies(
@@ -281,8 +283,10 @@ isl_bool isl_basic_map_is_subset(__isl_keep isl_basic_map *bmap1,
 isl_bool isl_basic_map_is_strict_subset(__isl_keep isl_basic_map *bmap1,
 		__isl_keep isl_basic_map *bmap2);
 
+__isl_export
 __isl_give isl_map *isl_map_universe(__isl_take isl_space *space);
 __isl_give isl_map *isl_map_nat_universe(__isl_take isl_space *dim);
+__isl_export
 __isl_give isl_map *isl_map_empty(__isl_take isl_space *space);
 __isl_give isl_map *isl_map_identity(__isl_take isl_space *dim);
 __isl_give isl_map *isl_map_lex_lt_first(__isl_take isl_space *dim, unsigned n);

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -91,7 +91,9 @@ int isl_basic_set_is_rational(__isl_keep isl_basic_set *bset);
 
 __isl_null isl_basic_set *isl_basic_set_free(__isl_take isl_basic_set *bset);
 __isl_give isl_basic_set *isl_basic_set_copy(__isl_keep isl_basic_set *bset);
+__isl_export
 __isl_give isl_basic_set *isl_basic_set_empty(__isl_take isl_space *space);
+__isl_export
 __isl_give isl_basic_set *isl_basic_set_universe(__isl_take isl_space *space);
 __isl_give isl_basic_set *isl_basic_set_nat_universe(__isl_take isl_space *dim);
 __isl_give isl_basic_set *isl_basic_set_positive_orthant(
@@ -236,7 +238,9 @@ isl_bool isl_basic_set_is_subset(__isl_keep isl_basic_set *bset1,
 isl_bool isl_basic_set_plain_is_equal(__isl_keep isl_basic_set *bset1,
 	__isl_keep isl_basic_set *bset2);
 
+__isl_export
 __isl_give isl_set *isl_set_empty(__isl_take isl_space *space);
+__isl_export
 __isl_give isl_set *isl_set_universe(__isl_take isl_space *space);
 __isl_give isl_set *isl_set_nat_universe(__isl_take isl_space *dim);
 __isl_give isl_set *isl_set_copy(__isl_keep isl_set *set);

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -37,6 +37,20 @@ __isl_give isl_space *isl_space_alloc(isl_ctx *ctx,
 __isl_give isl_space *isl_space_set_alloc(isl_ctx *ctx,
 			unsigned nparam, unsigned dim);
 __isl_give isl_space *isl_space_params_alloc(isl_ctx *ctx, unsigned nparam);
+
+__isl_give isl_space *isl_space_map_alloc_noparams(isl_ctx *ctx,
+	unsigned n_in, unsigned n_out);
+__isl_give isl_space *isl_space_set_alloc_noparams(isl_ctx *ctx,
+	unsigned n_set);
+__isl_give isl_space *isl_space_params_alloc_empty(isl_ctx *ctx);
+
+__isl_give isl_space *isl_space_map_alloc_from_id_list(
+	__isl_take isl_id_list *param_ids, unsigned n_in, unsigned n_out);
+__isl_give isl_space *isl_space_set_alloc_from_id_list(
+	__isl_take isl_id_list *param_ids, unsigned n_set);
+__isl_give isl_space *isl_space_params_alloc_from_id_list(
+	__isl_take isl_id_list *param_ids);
+
 __isl_give isl_space *isl_space_copy(__isl_keep isl_space *dim);
 __isl_null isl_space *isl_space_free(__isl_take isl_space *space);
 

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-struct isl_space;
+struct __isl_export isl_space;
 typedef struct isl_space isl_space;
 
 enum isl_dim_type {
@@ -38,10 +38,13 @@ __isl_give isl_space *isl_space_set_alloc(isl_ctx *ctx,
 			unsigned nparam, unsigned dim);
 __isl_give isl_space *isl_space_params_alloc(isl_ctx *ctx, unsigned nparam);
 
+__isl_constructor
 __isl_give isl_space *isl_space_map_alloc_noparams(isl_ctx *ctx,
 	unsigned n_in, unsigned n_out);
+__isl_constructor
 __isl_give isl_space *isl_space_set_alloc_noparams(isl_ctx *ctx,
 	unsigned n_set);
+__isl_constructor
 __isl_give isl_space *isl_space_params_alloc_empty(isl_ctx *ctx);
 
 __isl_give isl_space *isl_space_map_alloc_from_id_list(

--- a/include/isl/union_map.h
+++ b/include/isl/union_map.h
@@ -24,6 +24,7 @@ __isl_give isl_union_map *isl_union_map_from_basic_map(
 	__isl_take isl_basic_map *bmap);
 __isl_constructor
 __isl_give isl_union_map *isl_union_map_from_map(__isl_take isl_map *map);
+__isl_export
 __isl_give isl_union_map *isl_union_map_empty(__isl_take isl_space *space);
 __isl_give isl_union_map *isl_union_map_copy(__isl_keep isl_union_map *umap);
 __isl_null isl_union_map *isl_union_map_free(__isl_take isl_union_map *umap);

--- a/include/isl/union_set.h
+++ b/include/isl/union_set.h
@@ -16,6 +16,7 @@ __isl_give isl_union_set *isl_union_set_from_basic_set(
 	__isl_take isl_basic_set *bset);
 __isl_constructor
 __isl_give isl_union_set *isl_union_set_from_set(__isl_take isl_set *set);
+__isl_export
 __isl_give isl_union_set *isl_union_set_empty(__isl_take isl_space *space);
 __isl_give isl_union_set *isl_union_set_copy(__isl_keep isl_union_set *uset);
 __isl_null isl_union_set *isl_union_set_free(__isl_take isl_union_set *uset);

--- a/isl_space.c
+++ b/isl_space.c
@@ -51,6 +51,59 @@ __isl_give isl_space *isl_space_alloc(isl_ctx *ctx,
 	return dim;
 }
 
+/* Allocate a map space without any parameter dimensions.
+ */
+__isl_give isl_space *isl_space_map_alloc_noparams(isl_ctx *ctx,
+	unsigned n_in, unsigned n_out)
+{
+	return isl_space_alloc(ctx, 0, n_in, n_out);
+}
+
+/* Allocate a map space without any parameter dimensions.
+ */
+__isl_give isl_space *isl_space_set_alloc_noparams(isl_ctx *ctx,
+	unsigned n_set)
+{
+	return isl_space_set_alloc(ctx, 0, n_set);
+}
+
+/* Allocate a parameter space without any parameter dimensions.
+ */
+__isl_give isl_space *isl_space_params_alloc_empty(isl_ctx *ctx)
+{
+	return isl_space_params_alloc(ctx, 0);
+}
+
+/* Allocate a map space with named parameter dimensions.
+ */
+__isl_give isl_space *isl_space_map_alloc_from_id_list(
+	__isl_take isl_id_list *param_ids, unsigned n_in, unsigned n_out)
+{
+	isl_ctx *ctx;
+	isl_space *space;
+	unsigned nparam;
+	int i;
+
+	if (!param_ids)
+		return NULL;
+
+	ctx = isl_id_list_get_ctx(param_ids);
+	nparam = isl_id_list_n_id(param_ids);
+	space = isl_space_alloc(ctx, nparam, n_in, n_out);
+
+	if (!space)
+		return NULL;
+
+	for (i = 0; i < nparam; i++) {
+		isl_id *id = isl_id_list_get_id(param_ids, i);
+		space = isl_space_set_dim_id(space, isl_dim_param, i, id);
+	}
+
+	isl_id_list_free(param_ids);
+
+	return space;
+}
+
 /* Mark the space as being that of a set, by setting the domain tuple
  * to isl_id_none.
  */
@@ -95,6 +148,18 @@ __isl_give isl_space *isl_space_set_alloc(isl_ctx *ctx,
 	return space;
 }
 
+/* Allocate a set space with named parameter dimensions.
+ */
+__isl_give isl_space *isl_space_set_alloc_from_id_list(
+	__isl_take isl_id_list *param_ids, unsigned n_set)
+{
+	isl_space *space;
+
+	space = isl_space_map_alloc_from_id_list(param_ids, 0, n_set);
+	space = mark_as_set(space);
+	return space;
+}
+
 /* Mark the space as being that of a parameter domain, by setting
  * both tuples to isl_id_none.
  */
@@ -104,6 +169,17 @@ static __isl_give isl_space *mark_as_params(isl_space *space)
 		return NULL;
 	space = isl_space_set_tuple_id(space, isl_dim_in, &isl_id_none);
 	space = isl_space_set_tuple_id(space, isl_dim_out, &isl_id_none);
+	return space;
+}
+
+/* Allocate a parameter space with named parameter dimensions.
+ */
+__isl_give isl_space *isl_space_params_alloc_from_id_list(
+	__isl_take isl_id_list *param_ids)
+{
+	isl_space *space;
+	space = isl_space_map_alloc_from_id_list(param_ids, 0, 0);
+	space = mark_as_params(space);
 	return space;
 }
 


### PR DESCRIPTION
Export isl_space as well as empty and universe constructors for isl sets and maps.