### PR TITLE
cpp: construct bindings that take a default context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: c
+
+compiler:
+        - clang
+        - gcc
+
+os:
+        - linux
+
+# OSX builds do not work yet
+#        - osx
+
+osx_image: xcode9
+
+dist: trusty
+
+before_install:
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gmp     ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --with-clang --with-lld --with-python llvm ; fi
+        - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libgmp-dev libedit-dev ; fi
+        - export PATH=/usr/local/opt/llvm/bin:$PATH
+        - git submodule init
+        - git submodule update
+env:
+        - INT=gmp
+        - INT=imath
+        - INT=imath-32
+
+script:
+        - ./autogen.sh && ./configure --with-int=$INT --with-clang=system && make && make check

--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -282,6 +282,9 @@ void cpp_generator::print_constructors_decl(ostream &os,
 		function_kind kind = function_kind_constructor;
 
 		print_method_decl(os, clazz, fullname, cons, kind);
+		if (has_ctx_as_first_argument(cons))
+			print_method_decl(os, clazz, fullname, cons, kind, true);
+
 	}
 }
 
@@ -381,6 +384,8 @@ void cpp_generator::print_method_group_decl(ostream &os, const isl_class &clazz,
 	for (it = methods.begin(); it != methods.end(); ++it) {
 		function_kind kind = get_method_kind(clazz, *it);
 		print_method_decl(os, clazz, fullname, *it, kind);
+		if (has_ctx_as_first_argument(*it))
+		  print_method_decl(os, clazz, fullname, *it, kind, true);
 	}
 }
 
@@ -393,9 +398,10 @@ void cpp_generator::print_method_group_decl(ostream &os, const isl_class &clazz,
  * "kind" specifies the kind of method that should be generated.
  */
 void cpp_generator::print_method_decl(ostream &os, const isl_class &clazz,
-	const string &fullname, FunctionDecl *method, function_kind kind)
+	const string &fullname, FunctionDecl *method, function_kind kind,
+	bool hide_constructor)
 {
-	print_method_header(os, clazz, method, fullname, true, kind);
+	print_method_header(os, clazz, method, fullname, true, kind, hide_constructor);
 }
 
 /* Print implementations for class "clazz" to "os".
@@ -479,6 +485,8 @@ void cpp_generator::print_constructors_impl(ostream &os,
 		function_kind kind = function_kind_constructor;
 
 		print_method_impl(os, clazz, fullname, cons, kind);
+		if (has_ctx_as_first_argument(cons))
+		  print_method_impl(os, clazz, fullname, cons, kind, true);
 	}
 }
 
@@ -576,6 +584,8 @@ void cpp_generator::print_method_group_impl(ostream &os, const isl_class &clazz,
 			osprintf(os, "\n");
 		kind = get_method_kind(clazz, *it);
 		print_method_impl(os, clazz, fullname, *it, kind);
+		if (has_ctx_as_first_argument(*it))
+		  print_method_impl(os, clazz, fullname, *it, kind, true);
 	}
 }
 
@@ -664,7 +674,8 @@ void cpp_generator::print_method_param_use(ostream &os, ParmVarDecl *param,
  * as part of the std::function argument which specifies the callback function.
  */
 void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
-	const string &fullname, FunctionDecl *method, function_kind kind)
+	const string &fullname, FunctionDecl *method, function_kind kind,
+	bool hide_constructor)
 {
 	string cname = fullname.substr(clazz.name.length() + 1);
 	string methodname = method->getName();
@@ -673,7 +684,7 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 	string rettype_str = type2cpp(return_type);
 	bool has_callback = false;
 
-	print_method_header(os, clazz, method, fullname, false, kind);
+	print_method_header(os, clazz, method, fullname, false, kind, hide_constructor);
 
 	for (int i = 0; i < num_params; ++i) {
 		ParmVarDecl *param = method->getParamDecl(i);
@@ -693,7 +704,10 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 		if (i == 0 && kind == function_kind_member_method)
 			load_from_this_ptr = true;
 
-		print_method_param_use(os, param, load_from_this_ptr);
+		if (i == 0 && hide_constructor)
+			osprintf(os, "ctx::get_default_ctx().get()");
+		else
+			print_method_param_use(os, param, load_from_this_ptr);
 
 		if (i != num_params - 1)
 			osprintf(os, ", ");
@@ -763,7 +777,7 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
  */
 void cpp_generator::print_method_header(ostream &os, const isl_class &clazz,
 	FunctionDecl *method, const string &fullname, bool is_declaration,
-	function_kind kind)
+	function_kind kind, bool hide_constructor)
 {
 	string cname = fullname.substr(clazz.name.length() + 1);
 	string rettype_str = type2cpp(method->getReturnType());
@@ -774,6 +788,11 @@ void cpp_generator::print_method_header(ostream &os, const isl_class &clazz,
 	cname = rename_method(cname);
 	if (kind == function_kind_member_method)
 		first_param = 1;
+
+	if (hide_constructor) {
+		fprintf(stderr, "Test\n");
+		first_param++;
+	}
 
 	if (is_declaration) {
 		osprintf(os, "  ");

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -37,7 +37,7 @@ private:
 		const string &fullname, const set<FunctionDecl *> &methods);
 	void print_method_decl(ostream &os, const isl_class &clazz,
 		const string &fullname, FunctionDecl *method,
-		function_kind kind);
+		function_kind kind, bool hide_constructor = false);
 	void print_implementations(ostream &os);
 	void print_class_impl(ostream &os, const isl_class &clazz);
 	void print_class_factory_impl(ostream &os, const isl_class &clazz);
@@ -54,12 +54,12 @@ private:
 		const string &fullname, const set<FunctionDecl *> &methods);
 	void print_method_impl(ostream &os, const isl_class &clazz,
 		const string &fullname,	FunctionDecl *method,
-		function_kind kind);
+		function_kind kind, bool hide_constructor = false);
 	void print_method_param_use(ostream &os, ParmVarDecl *param,
 		bool load_from_this_ptr);
 	void print_method_header(ostream &os, const isl_class &clazz,
 		FunctionDecl *method, const string &fullname,
-		bool is_declaration, function_kind kind);
+		bool is_declaration, function_kind kind, bool hide_constructor);
 	string generate_callback_args(QualType type, bool cpp);
 	string generate_callback_type(QualType type);
 	void print_callback_local(ostream &os, ParmVarDecl *param);

--- a/interface/generator.cc
+++ b/interface/generator.cc
@@ -54,6 +54,16 @@ bool generator::is_static(const isl_class &clazz, FunctionDecl *method)
 	return extract_type(type) != clazz.name;
 }
 
+/* Is "method" constructed with isl_ctx as first argument?
+ */
+bool generator::has_ctx_as_first_argument(FunctionDecl *method)
+{
+	ParmVarDecl *param = method->getParamDecl(0);
+	QualType type = param->getOriginalType();
+
+	return is_isl_ctx(type) && method->getNumParams() >= 2;
+}
+
 /* Find the FunctionDecl with name "name",
  * returning NULL if there is no such FunctionDecl.
  * If "required" is set, then error out if no FunctionDecl can be found.

--- a/interface/generator.h
+++ b/interface/generator.h
@@ -65,6 +65,7 @@ protected:
 	bool is_callback(QualType type);
 	bool is_string(QualType type);
 	bool is_static(const isl_class &clazz, FunctionDecl *method);
+	bool has_ctx_as_first_argument(FunctionDecl *Method);
 	string extract_type(QualType type);
 	FunctionDecl *find_by_name(const string &name, bool required);
 };

--- a/interface/isl.h.top
+++ b/interface/isl.h.top
@@ -73,6 +73,7 @@ inline isl::boolean manage(isl_bool val) {
 
 class ctx {
   isl_ctx *ptr;
+
 public:
   /* implicit */ ctx(isl_ctx *ctx)
       : ptr(ctx) {}
@@ -84,6 +85,15 @@ public:
   isl_ctx *get() {
     return ptr;
   }
+
+  static isl::ctx get_default_ctx() {
+     static thread_local isl_ctx *default_ctx = NULL;
+
+    if (!default_ctx)
+      default_ctx = isl_ctx_alloc();
+
+    return default_ctx;
+  };
 };
 
 enum class stat {

--- a/interface/isl_test_cpp.cpp
+++ b/interface/isl_test_cpp.cpp
@@ -307,6 +307,15 @@ void test_foreach(isl::ctx ctx)
 	assert(ret2 == isl::stat::error);
 }
 
+void test_default_ctx() {
+	isl::set S1("{ [1] } ");
+	isl::set S2("{ [2] } ");
+
+	isl::set S12("{ [1] ; [2] } ");
+
+	assert(S1.unite(S2).is_equal(S12));
+}
+
 /* Test the isl C++ interface
  *
  * This includes:
@@ -327,4 +336,6 @@ int main()
 	test_foreach(ctx);
 
 	isl_ctx_free(ctx);
+
+	test_default_ctx();
 }


### PR DESCRIPTION
Here an idea how #14 could be addressed.

Not sure what to do with constructors that do not take any other arguments. How should the be distinguished from a default constructor that constructs an empty object. This currently happens only with isl_ast_build.