### PR TITLE
cpp: generate isl::managed_copy for all exported classes

### DIFF
--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -157,8 +157,7 @@ void cpp_generator::print_class(ostream &os, const isl_class &clazz)
 	print_class_factory_decl(os, clazz);
 	osprintf(os, "\n");
 	osprintf(os, "class %s {\n", cppname);
-	osprintf(os, "  friend ");
-	print_class_factory_decl(os, clazz);
+	print_class_factory_decl(os, clazz, "  friend ");
 	osprintf(os, "\n");
 	osprintf(os, "  %s *ptr = nullptr;\n", name);
 	osprintf(os, "\n");
@@ -187,28 +186,34 @@ void cpp_generator::print_class_forward_decl(ostream &os,
 	osprintf(os, "class %s;\n", cppname);
 }
 
-/* Print global factory function to "os".
+/* Print global factory functions to "os".
  *
- * Each class has one global factory function:
+ * Each class has two global factory functions:
  *
  * 	isl::set manage(__isl_take isl_set *ptr);
+ * 	isl::set managed_copy(__isl_keep isl_set *ptr);
  *
- * The only public way to construct isl C++ objects from a raw pointer is
- * through this global factory function. This ensures isl object creation
- * is very explicit and pointers are not converted by accident. Due to
- * overloading, manage() can be called on any isl raw pointer and the
- * corresponding object is automatically created, without the user having
- * to choose the right isl object type.
+ * A user can construct isl C++ objects from a raw pointer and indicate whether
+ * they intend to take the ownership of the object or not through these global
+ * factory functions. This ensures isl object creation is very explicit and
+ * pointers are not converted by accident. Thanks to overloading, manage() and
+ * managed_copy() can be called on any isl raw pointer and the corresponding
+ * object is automatically created, without the user having to choose the right
+ * isl object type.
  */
 void cpp_generator::print_class_factory_decl(ostream &os,
-	const isl_class &clazz)
+	const isl_class &clazz, const std::string &prefix)
 {
 	const char *name = clazz.name.c_str();
 	std::string cppstring = type2cpp(clazz);
 	const char *cppname = cppstring.c_str();
 
+	os << prefix;
 	osprintf(os, "inline isl::%s manage(__isl_take %s *ptr);\n", cppname,
 		 name);
+	os << prefix;
+	osprintf(os, "inline isl::%s managed_copy(__isl_keep %s *ptr);\n",
+		cppname, name);
 }
 
 /* Print declarations of private constructors for class "clazz" to "os".
@@ -222,7 +227,7 @@ void cpp_generator::print_class_factory_decl(ostream &os,
  * 	set(__isl_take isl_set *ptr);
  *
  * The raw pointer constructor is kept private. Object creation is only
- * possible through isl::manage().
+ * possible through isl::manage() or isl::managed_copy().
  */
 void cpp_generator::print_private_constructors_decl(ostream &os,
 	const isl_class &clazz)
@@ -435,6 +440,11 @@ void cpp_generator::print_class_factory_impl(ostream &os,
 
 	osprintf(os, "isl::%s manage(__isl_take %s *ptr) {\n", cppname, name);
 	osprintf(os, "  return %s(ptr);\n", cppname);
+	osprintf(os, "}\n");
+	osprintf(os, "\n");
+	osprintf(os, "isl::%s managed_copy(__isl_keep %s *ptr) {\n", cppname,
+		name);
+	osprintf(os, "  return %s(%s_copy(ptr));\n", cppname, name);
 	osprintf(os, "}\n");
 }
 

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -23,7 +23,8 @@ private:
 	void print_declarations(ostream &os);
 	void print_class(ostream &os, const isl_class &clazz);
 	void print_class_forward_decl(ostream &os, const isl_class &clazz);
-	void print_class_factory_decl(ostream &os, const isl_class &clazz);
+	void print_class_factory_decl(ostream &os, const isl_class &clazz,
+		const std::string &prefix = std::string());
 	void print_private_constructors_decl(ostream &os,
 		const isl_class &clazz);
 	void print_copy_assignment_decl(ostream &os, const isl_class &clazz);


### PR DESCRIPTION
Provide a set of overloaded functions isl::managed_copy(__isl_keep isl_class*)
that return a C++-wrapped copy of the given object. Contrary to isl::manage,
these functions do not take ownership of the given object and will not destroy
it when the last C++ copy goes out of scope.  This simplifies the interaction
with C code using isl, specifically with other libraries such as ppcg.

Signed-off-by: Oleksandr Zinenko <git@ozinenko.com>

Closes #9 