### PR TITLE
cpp: export id

### DIFF
--- a/include/isl/id.h
+++ b/include/isl/id.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-struct isl_id;
+struct __isl_export isl_id;
 typedef struct isl_id isl_id;
 
 ISL_DECLARE_LIST(id)
@@ -23,7 +23,9 @@ __isl_give isl_id *isl_id_alloc(isl_ctx *ctx,
 __isl_give isl_id *isl_id_copy(isl_id *id);
 __isl_null isl_id *isl_id_free(__isl_take isl_id *id);
 
+__isl_export
 void *isl_id_get_user(__isl_keep isl_id *id);
+__isl_export
 __isl_keep const char *isl_id_get_name(__isl_keep isl_id *id);
 
 __isl_give isl_id *isl_id_set_free_user(__isl_take isl_id *id,

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -75,10 +75,13 @@ isl_bool isl_set_has_dim_id(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
 __isl_give isl_id *isl_set_get_dim_id(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
+__isl_export
 __isl_give isl_set *isl_set_set_tuple_id(__isl_take isl_set *set,
 	__isl_take isl_id *id);
 __isl_give isl_set *isl_set_reset_tuple_id(__isl_take isl_set *set);
+__isl_export
 isl_bool isl_set_has_tuple_id(__isl_keep isl_set *set);
+__isl_export
 __isl_give isl_id *isl_set_get_tuple_id(__isl_keep isl_set *set);
 __isl_give isl_set *isl_set_reset_user(__isl_take isl_set *set);
 

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -34,6 +34,7 @@ private:
 	void print_destructor_decl(ostream &os, const isl_class &clazz);
 	void print_ptr_decl(ostream &os, const isl_class &clazz);
 	void print_methods_decl(ostream &os, const isl_class &clazz);
+	void print_custom_public_decl(ostream &os, const isl_class &clazz);
 	void print_method_group_decl(ostream &os, const isl_class &clazz,
 		const string &fullname, const set<FunctionDecl *> &methods);
 	void print_method_decl(ostream &os, const isl_class &clazz,
@@ -51,6 +52,7 @@ private:
 	void print_destructor_impl(ostream &os, const isl_class &clazz);
 	void print_ptr_impl(ostream &os, const isl_class &clazz);
 	void print_methods_impl(ostream &os, const isl_class &clazz);
+	void print_custom_methods_impl(ostream &os, const isl_class &clazz);
 	void print_method_group_impl(ostream &os, const isl_class &clazz,
 		const string &fullname, const set<FunctionDecl *> &methods);
 	void print_method_impl(ostream &os, const isl_class &clazz,


### PR DESCRIPTION
Introduce special behavior for the id class with two features: disallow unnamed
ids by construction, ensure that ids remain value-comparable.

Generally, isl_id behaves like a reference-counted smart pointer to the name
string and the user pointer. Additionally, it guarantees that ids with
identical names and user pointers are pointer-comparable. An id object can have
a "user_free" callback that is called when the reference counter reaches zero.
Existing mechanism for callbacks does not apply to "user_free" callbacks as it
modifies the user object passed to the callback. In particular, it creates a
new object of a custom type in each call of the function that takes a callback
and passes it instead of the original user pointer. Therefore, two ids
constructed independently from the same user pointer would no longer be
pointer-comparable. Therefore, one must pass the user pointer directly. The
"user_free" callback must in turn remain a C function pointer. An alternative
solution that supports std::function would require maintaining a map between
user pointers and custom objects that were passed when constructing isl_ids;
however, it would break direct comparability between isl_ids constructed using
C and C++ interface.

Support void and void * as return and argument types in the generator. Modify
the generator to inject custom method declarations and definitions in the class
based on the class name. Inject custom constructors, utility methods and
comparison operators for isl::id. Custom constructors take either a name or a
user pointer, or both. The "user_free" callback can be optionally provided in
constructors or set up separately. This callback must be a C function pointer
because it will be called from the C code. The user pointer is passed as
void *, which can be replaced by template methods in the future, except in the
"user_free" callback.  The "set_user_free" function is injected so as to avoid
handling a special case in callback generation.

Closes #8 