### PR TITLE
cpp/python: export isl_id

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -896,6 +896,8 @@ using the following functions.
 	#include <isl/id.h>
 	__isl_give isl_id *isl_id_alloc(isl_ctx *ctx,
 		__isl_keep const char *name, void *user);
+	__isl_give isl_id *isl_id_from_name(isl_ctx *ctx,
+		__isl_keep const char *name);
 	__isl_give isl_id *isl_id_set_free_user(
 		__isl_take isl_id *id,
 		void (*free_user)(void *user));
@@ -903,6 +905,7 @@ using the following functions.
 	__isl_null isl_id *isl_id_free(__isl_take isl_id *id);
 
 	void *isl_id_get_user(__isl_keep isl_id *id);
+	isl_bool isl_id_has_name(__isl_keep isl_id *id);
 	__isl_keep const char *isl_id_get_name(__isl_keep isl_id *id);
 
 	__isl_give isl_printer *isl_printer_print_id(

--- a/include/isl/id.h
+++ b/include/isl/id.h
@@ -20,11 +20,14 @@ uint32_t isl_id_get_hash(__isl_keep isl_id *id);
 
 __isl_give isl_id *isl_id_alloc(isl_ctx *ctx,
 	__isl_keep const char *name, void *user);
+__isl_give isl_id *isl_id_from_name(isl_ctx *ctx,
+	__isl_keep const char *name);
 __isl_give isl_id *isl_id_copy(isl_id *id);
 __isl_null isl_id *isl_id_free(__isl_take isl_id *id);
 
 void *isl_id_get_user(__isl_keep isl_id *id);
 __isl_keep const char *isl_id_get_name(__isl_keep isl_id *id);
+isl_bool isl_id_has_name(__isl_keep isl_id *id);
 
 __isl_give isl_id *isl_id_set_free_user(__isl_take isl_id *id,
 	void (*free_user)(void *user));

--- a/include/isl/id.h
+++ b/include/isl/id.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-struct isl_id;
+struct __isl_export isl_id;
 typedef struct isl_id isl_id;
 
 ISL_DECLARE_LIST(id)
@@ -20,13 +20,16 @@ uint32_t isl_id_get_hash(__isl_keep isl_id *id);
 
 __isl_give isl_id *isl_id_alloc(isl_ctx *ctx,
 	__isl_keep const char *name, void *user);
+__isl_constructor
 __isl_give isl_id *isl_id_from_name(isl_ctx *ctx,
 	__isl_keep const char *name);
 __isl_give isl_id *isl_id_copy(isl_id *id);
 __isl_null isl_id *isl_id_free(__isl_take isl_id *id);
 
 void *isl_id_get_user(__isl_keep isl_id *id);
+__isl_export
 __isl_keep const char *isl_id_get_name(__isl_keep isl_id *id);
+__isl_export
 isl_bool isl_id_has_name(__isl_keep isl_id *id);
 
 __isl_give isl_id *isl_id_set_free_user(__isl_take isl_id *id,

--- a/isl_id.c
+++ b/isl_id.c
@@ -42,6 +42,14 @@ const char *isl_id_get_name(__isl_keep isl_id *id)
 	return id ? id->name : NULL;
 }
 
+isl_bool isl_id_has_name(__isl_keep isl_id *id)
+{
+	if (!id)
+		return isl_bool_error;
+
+	return id->name ? isl_bool_true : isl_bool_false;
+}
+
 static __isl_give isl_id *id_alloc(isl_ctx *ctx, const char *name, void *user)
 {
 	const char *copy = name ? strdup(name) : NULL;
@@ -120,6 +128,16 @@ __isl_give isl_id *isl_id_alloc(isl_ctx *ctx, const char *name, void *user)
 	if (!entry->data)
 		ctx->id_table.n--;
 	return entry->data;
+}
+
+/* Construct an isl_id with a given "name" and a NULL user field.
+ */
+__isl_give isl_id *isl_id_from_name(isl_ctx *ctx, const char *name)
+{
+	if (!name)
+		return NULL;
+
+	return isl_id_alloc(ctx, name, NULL);
 }
 
 /* If the id has a negative refcount, then it is a static isl_id


### PR DESCRIPTION
Export isl_id allocation and name management. Disallow unnamed identifiers by
construction and hide user pointers.

Identifiers can have an optional name and an optional user pointer. However,
identifiers without a name and a user pointer are forbidden. The user pointer
is a void * pointer to a C data structure, managed and potentially deallocated
within C code. It is not fully compatible with C++ objects featuring a virtual
destructor and not sufficiently type-safe. The notion of pointer does not exist
in Python. Therefore, it makes sense to hide the presence of a user pointer
from the bindings. This is achieved by providing the "isl_id_from_name"
(constructor) function that only takes a name of the identifier. If necessary,
user pointers may be accessed through C API, but doing so should be
discouraged. As an alternative, a user of C++ or Python bindings may maintain a
mapping between identifier objects and arbitrary data.

The equality of pointer objects is preserved. However, hiding user pointers may
lead to a situation where two identifier objects in C++ or Python are not equal
although their visible attributes (names) are equal. This can only happen if at
least one of the pointers was obtained from C code.

Since identifiers constructed in C are allowed to not have a name, i.e. have a
NULL name, which cannot be expressed as a C++ std::string, provide an
additional function "isl_id_has_name" to check whether the name is not NULL.

Signed-off-by: Oleksandr Zinenko <git@ozinenko.com>