### PR TITLE
cpp/python: flag to force generation of static methods

### DIFF
--- a/include/isl/ctx.h
+++ b/include/isl/ctx.h
@@ -33,6 +33,9 @@
 #ifndef __isl_overload
 #define __isl_overload
 #endif
+#ifndef __isl_ensure_static
+#define __isl_ensure_static
+#endif
 #ifndef __isl_constructor
 #define __isl_constructor
 #endif

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -219,6 +219,7 @@ __isl_give isl_basic_set *isl_basic_set_params(__isl_take isl_basic_set *bset);
 __isl_give isl_basic_set *isl_basic_set_from_params(
 	__isl_take isl_basic_set *bset);
 __isl_give isl_set *isl_set_params(__isl_take isl_set *set);
+__isl_ensure_static
 __isl_give isl_set *isl_set_from_params(__isl_take isl_set *set);
 
 isl_stat isl_basic_set_dims_get_sign(__isl_keep isl_basic_set *bset,
@@ -374,6 +375,7 @@ isl_bool isl_set_involves_dims(__isl_keep isl_set *set,
 void isl_set_print_internal(__isl_keep isl_set *set, FILE *out, int indent);
 isl_bool isl_set_plain_is_empty(__isl_keep isl_set *set);
 isl_bool isl_set_plain_is_universe(__isl_keep isl_set *set);
+__isl_export
 isl_bool isl_set_is_params(__isl_keep isl_set *set);
 __isl_export
 isl_bool isl_set_is_empty(__isl_keep isl_set *set);

--- a/interface/extract_interface.cc
+++ b/interface/extract_interface.cc
@@ -426,6 +426,9 @@ int main(int argc, char *argv[])
 	PO.addMacroDef("__isl_overload="
 	    "__attribute__((annotate(\"isl_overload\"))) "
 	    "__attribute__((annotate(\"isl_export\")))");
+	PO.addMacroDef("__isl_ensure_static="
+	    "__attribute__((annotate(\"isl_ensure_static\"))) "
+	    "__attribute__((annotate(\"isl_export\")))");
 	PO.addMacroDef("__isl_constructor=__attribute__((annotate(\"isl_constructor\"))) __attribute__((annotate(\"isl_export\")))");
 	PO.addMacroDef("__isl_subclass(super)=__attribute__((annotate(\"isl_subclass(\" #super \")\"))) __attribute__((annotate(\"isl_export\")))");
 

--- a/interface/generator.cc
+++ b/interface/generator.cc
@@ -46,6 +46,9 @@
  */
 bool generator::is_static(const isl_class &clazz, FunctionDecl *method)
 {
+	if (is_ensure_static(method))
+		return true;
+
 	ParmVarDecl *param = method->getParamDecl(0);
 	QualType type = param->getOriginalType();
 
@@ -172,6 +175,13 @@ bool generator::is_overload(Decl *decl)
 bool generator::is_constructor(Decl *decl)
 {
 	return has_annotation(decl, "isl_constructor");
+}
+
+/* Is decl marked as ensure_static?
+ */
+bool generator::is_ensure_static(Decl *decl)
+{
+	return has_annotation(decl, "isl_ensure_static");
 }
 
 /* Is decl marked as consuming a reference?

--- a/interface/generator.h
+++ b/interface/generator.h
@@ -52,6 +52,7 @@ protected:
 	vector<string> find_superclasses(RecordDecl *decl);
 	bool is_overload(Decl *decl);
 	bool is_constructor(Decl *decl);
+	bool is_ensure_static(Decl *decl);
 	bool takes(Decl *decl);
 	bool keeps(Decl *decl);
 	bool gives(Decl *decl);

--- a/interface/isl_test_cpp.cpp
+++ b/interface/isl_test_cpp.cpp
@@ -314,6 +314,17 @@ void test_foreach(isl::ctx ctx)
 	assert(ret2 == isl::stat::error);
 }
 
+/* Test that ensure_static indeed generates static methods.
+ */
+void test_ensure_static(isl::ctx ctx)
+{
+	isl::set s(ctx, "[N] -> {:}");
+	assert(s.is_params());
+
+	isl::set ss = isl::set::from_params(s);
+	assert(ss.is_params().is_false());
+}
+
 /* Test the isl C++ interface
  *
  * This includes:
@@ -322,6 +333,7 @@ void test_foreach(isl::ctx ctx)
  *  - Different parameter types
  *  - Different return types
  *  - Foreach functions
+ *  - Methods marked ensure_static
  */
 int main()
 {
@@ -332,6 +344,7 @@ int main()
 	test_parameters(ctx);
 	test_return(ctx);
 	test_foreach(ctx);
+	test_ensure_static(ctx);
 
 	isl_ctx_free(ctx);
 }


### PR DESCRIPTION
Introduce the __isl_ensure_static macro that forces the generators to make the
method static if it would otherwise be an instance member function.

This macro is primarily intended for static constructors of an object from
another object of the same type, which are present in sets and spaces. Marking
such methods as constructors would interfere with standard copy construction.
Exporting them directly masks the fact of construction and is inconsistent with
other static methods serving as named constructors. Consider readbility of

	isl::set s = isl::set::from_params(another_set);

enabled by this macro against

	isl::set s = another_set.from_params();

Closes #22 