### PR TITLE
Simplify construction of parameteric pw affs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 missing
+piplib
 py-compile
 stamp-h1
 test-driver

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -9959,18 +9959,22 @@ Exact division.  That is, the result is known to be an integer.
 
 Result of integer division, rounded towards negative
 infinity.
+The divisor is known to be positive.
 
 =item C<isl_ast_op_pdiv_q>
 
 Result of integer division, where dividend is known to be non-negative.
+The divisor is known to be positive.
 
 =item C<isl_ast_op_pdiv_r>
 
 Remainder of integer division, where dividend is known to be non-negative.
+The divisor is known to be positive.
 
 =item C<isl_ast_op_zdiv_r>
 
 Equal to zero iff the remainder on integer division is zero.
+The divisor is known to be positive.
 
 =item C<isl_ast_op_cond>
 
@@ -10139,7 +10143,10 @@ the context of an C<isl_ast_build>.
 
 The function C<isl_ast_expr_address_of> can be applied to an
 C<isl_ast_expr> of type C<isl_ast_op_access> only. It is meant
-to represent the address of the C<isl_ast_expr_access>. The function
+to represent the address of the C<isl_ast_expr_access>.
+The second argument of the functions C<isl_ast_expr_pdiv_q> and
+C<isl_ast_expr_pdiv_r> should always evaluate to a positive number.
+The function
 C<isl_ast_expr_and_then> as well as C<isl_ast_expr_or_else> are short-circuit
 versions of C<isl_ast_expr_and> and C<isl_ast_expr_or>, respectively.
 

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -10167,7 +10167,7 @@ versions of C<isl_ast_expr_and> and C<isl_ast_expr_or>, respectively.
 		__isl_keep isl_ast_build *build,
 		__isl_take isl_multi_pw_aff *mpa);
 
-The set <set> and
+The set C<set> and
 the domains of C<pa>, C<mpa> and C<pma> should correspond
 to the schedule space of C<build>.
 The tuple id of C<mpa> or C<pma> is used as the array being accessed or

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -3101,12 +3101,14 @@ create a piecewise expression over a domain that is a universe set in the given
 		__isl_take isl_space *space);
 
 The following convenience functions first create a base expression and then
-create a piecewise expression over a universe domain of a parameter space
-which contains exactly one parameter dimension corresponding to the given
-isl id.
+create a piecewise expression over a universe domain of a parameter space which
+contains exactly one parameter dimension corresponding to the given isl id or
+zero parameter dimensions in case an expression for a non-parametric constant
+value is constructed.
 
 	#include <isl/aff.h>
 	__isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);
+	__isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val);
 
 The following convenience functions first create a base expression and
 then create a piecewise expression over a given domain.

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -3109,6 +3109,8 @@ value is constructed.
 	#include <isl/aff.h>
 	__isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);
 	__isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val);
+	__isl_give isl_pw_aff *isl_pw_aff_val_from_si(__isl_keep isl_ctx *ctx,
+		int val);
 
 The following convenience functions first create a base expression and
 then create a piecewise expression over a given domain.

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -3072,8 +3072,9 @@ created using the following functions.
 		__isl_take isl_set *set,
 		__isl_take isl_qpolynomial *qp);
 
-The following convenience functions first create a base expression and
-then create a piecewise expression over a universe domain.
+The following convenience functions first create a base expression and then
+create a piecewise expression over a domain that is a universe set in the given
+(local) space.
 
 	#include <isl/aff.h>
 	__isl_give isl_pw_aff *isl_pw_aff_zero_on_domain(
@@ -3098,6 +3099,14 @@ then create a piecewise expression over a universe domain.
 	#include <isl/polynomial.h>
 	__isl_give isl_pw_qpolynomial *isl_pw_qpolynomial_zero(
 		__isl_take isl_space *space);
+
+The following convenience functions first create a base expression and then
+create a piecewise expression over a universe domain of a parameter space
+which contains exactly one parameter dimension corresponding to the given
+isl id.
+
+	#include <isl/aff.h>
+	__isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);
 
 The following convenience functions first create a base expression and
 then create a piecewise expression over a given domain.

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -198,6 +198,9 @@ __isl_give isl_pw_aff *isl_pw_aff_zero_on_domain(
 	__isl_take isl_local_space *ls);
 __isl_give isl_pw_aff *isl_pw_aff_var_on_domain(__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
+
+__isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);
+
 __isl_give isl_pw_aff *isl_pw_aff_nan_on_domain(__isl_take isl_local_space *ls);
 __isl_give isl_pw_aff *isl_pw_aff_val_on_domain(__isl_take isl_set *domain,
 	__isl_take isl_val *v);

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -201,6 +201,7 @@ __isl_give isl_pw_aff *isl_pw_aff_var_on_domain(__isl_take isl_local_space *ls,
 
 __isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);
 __isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val);
+__isl_give isl_pw_aff *isl_pw_aff_val_from_si(__isl_keep isl_ctx *ctx, int val);
 
 __isl_give isl_pw_aff *isl_pw_aff_nan_on_domain(__isl_take isl_local_space *ls);
 __isl_give isl_pw_aff *isl_pw_aff_val_on_domain(__isl_take isl_set *domain,

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -200,6 +200,7 @@ __isl_give isl_pw_aff *isl_pw_aff_var_on_domain(__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
 
 __isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);
+__isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val);
 
 __isl_give isl_pw_aff *isl_pw_aff_nan_on_domain(__isl_take isl_local_space *ls);
 __isl_give isl_pw_aff *isl_pw_aff_val_on_domain(__isl_take isl_set *domain,

--- a/isl_aff.c
+++ b/isl_aff.c
@@ -236,6 +236,21 @@ __isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id)
 	return isl_pw_aff_from_aff(aff);
 }
 
+/* Return a piecewise affine expression defined over a zero-dimensional
+ * parameter space. The value of the affine expression is "val".
+ */
+__isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val)
+{
+	isl_space *space;
+
+	if (!val)
+		return NULL;
+
+	space = isl_space_params_alloc(isl_val_get_ctx(val), 0);
+
+	return isl_pw_aff_val_on_domain(isl_set_universe(space), val);
+}
+
 /* Return a piecewise affine expression that is equal to
  * the specified dimension in "ls".
  */

--- a/isl_aff.c
+++ b/isl_aff.c
@@ -251,6 +251,21 @@ __isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val)
 	return isl_pw_aff_val_on_domain(isl_set_universe(space), val);
 }
 
+/* Return a piecewise affine expression defined over a zero-dimensional
+ * parameter space. The value of the affine expression is "val".
+ */
+__isl_give isl_pw_aff *isl_pw_aff_val_from_si(__isl_keep isl_ctx *ctx, int val)
+{
+	isl_val *v;
+
+	if (!ctx)
+		return NULL;
+
+	v = isl_val_int_from_si(ctx, v);
+
+	return isl_pw_aff_val_from_val(v);
+}
+
 /* Return a piecewise affine expression that is equal to
  * the specified dimension in "ls".
  */

--- a/isl_aff.c
+++ b/isl_aff.c
@@ -216,6 +216,26 @@ error:
 	return NULL;
 }
 
+/* Return a piecewise affine expression defined over a one-dimensional
+ * parameter space. The identifier of the single parameter dimension is "id".
+ * The value of the affine expression is equal to the single parameter
+ * identified by "id".
+ */
+__isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id)
+{
+	isl_space *space;
+	isl_aff *aff;
+
+	if (!id)
+		return NULL;
+
+	space = isl_space_params_alloc(isl_id_get_ctx(id), 1);
+	space = isl_space_set_dim_id(space, isl_dim_param, 0, isl_id_copy(id));
+	aff = isl_aff_param_on_domain_space_id(space, id);
+
+	return isl_pw_aff_from_aff(aff);
+}
+
 /* Return a piecewise affine expression that is equal to
  * the specified dimension in "ls".
  */

--- a/isl_list_templ.c
+++ b/isl_list_templ.c
@@ -251,11 +251,20 @@ int FN(FN(LIST(EL),n),BASE)(__isl_keep LIST(EL) *list)
 	return list ? list->n : 0;
 }
 
-__isl_give EL *FN(FN(LIST(EL),get),BASE)(__isl_keep LIST(EL) *list, int index)
+/* Return the element at position "index" in "list".
+ */
+static __isl_keep EL *FN(LIST(EL),peek)(__isl_keep LIST(EL) *list, int index)
 {
 	if (FN(LIST(EL),check_index)(list, index) < 0)
 		return NULL;
-	return FN(EL,copy)(list->p[index]);
+	return list->p[index];
+}
+
+/* Return a copy of the element at position "index" in "list".
+ */
+__isl_give EL *FN(FN(LIST(EL),get),BASE)(__isl_keep LIST(EL) *list, int index)
+{
+	return FN(EL,copy)(FN(LIST(EL),peek)(list, index));
 }
 
 /* Replace the element at position "index" in "list" by "el".

--- a/isl_multi_templ.c
+++ b/isl_multi_templ.c
@@ -476,6 +476,13 @@ error:
 	return NULL;
 }
 
+/* Create a multi expression in the given space with the elements of "list"
+ * as base expressions.
+ *
+ * Since isl_multi_*_set_* fails if the element and
+ * the multi expression do not have matching spaces, the alignment
+ * (if any) needs to be performed beforehand.
+ */
 __isl_give MULTI(BASE) *FN(FN(MULTI(BASE),from),LIST(BASE))(
 	__isl_take isl_space *space, __isl_take LIST(EL) *list)
 {
@@ -493,10 +500,15 @@ __isl_give MULTI(BASE) *FN(FN(MULTI(BASE),from),LIST(BASE))(
 		isl_die(ctx, isl_error_invalid,
 			"invalid number of elements in list", goto error);
 
+	for (i = 0; i < n; ++i) {
+		EL *el = FN(LIST(EL),peek)(list, i);
+		space = isl_space_align_params(space, FN(EL,get_space)(el));
+	}
 	multi = FN(MULTI(BASE),alloc)(isl_space_copy(space));
 	for (i = 0; i < n; ++i) {
-		multi = FN(FN(MULTI(BASE),set),BASE)(multi, i,
-					FN(FN(LIST(EL),get),BASE)(list, i));
+		EL *el = FN(FN(LIST(EL),get),BASE)(list, i);
+		el = FN(EL,align_params)(el, isl_space_copy(space));
+		multi = FN(FN(MULTI(BASE),set),BASE)(multi, i, el);
 	}
 
 	isl_space_free(space);

--- a/isl_multi_templ.c
+++ b/isl_multi_templ.c
@@ -494,8 +494,8 @@ error:
 /* Create a multi expression in the given space with the elements of "list"
  * as base expressions.
  *
- * Since isl_multi_*_set_* fails if the element and
- * the multi expression do not have matching spaces, the alignment
+ * Since isl_multi_*_restore_* assumes that the element and
+ * the multi expression have matching spaces, the alignment
  * (if any) needs to be performed beforehand.
  */
 __isl_give MULTI(BASE) *FN(FN(MULTI(BASE),from),LIST(BASE))(
@@ -523,7 +523,7 @@ __isl_give MULTI(BASE) *FN(FN(MULTI(BASE),from),LIST(BASE))(
 	for (i = 0; i < n; ++i) {
 		EL *el = FN(FN(LIST(EL),get),BASE)(list, i);
 		el = FN(EL,align_params)(el, isl_space_copy(space));
-		multi = FN(FN(MULTI(BASE),set),BASE)(multi, i, el);
+		multi = FN(MULTI(BASE),restore)(multi, i, el);
 	}
 
 	isl_space_free(space);

--- a/isl_test.c
+++ b/isl_test.c
@@ -5806,7 +5806,7 @@ static int test_residue_class(isl_ctx *ctx)
 	return res;
 }
 
-int test_align_parameters(isl_ctx *ctx)
+static int test_align_parameters_1(isl_ctx *ctx)
 {
 	const char *str;
 	isl_space *space;
@@ -5833,6 +5833,43 @@ int test_align_parameters(isl_ctx *ctx)
 	if (!equal)
 		isl_die(ctx, isl_error_unknown,
 			"result not as expected", return -1);
+
+	return 0;
+}
+
+/* Check the isl_multi_*_from_*_list operation in case inputs
+ * have unaligned parameters.
+ * In particular, older versions of isl would simply fail
+ * (without printing any error message).
+ */
+static isl_stat test_align_parameters_2(isl_ctx *ctx)
+{
+	isl_space *space;
+	isl_map *map;
+	isl_aff *aff;
+	isl_multi_aff *ma;
+
+	map = isl_map_read_from_str(ctx, "{ A[] -> M[x] }");
+	space = isl_map_get_space(map);
+	isl_map_free(map);
+
+	aff = isl_aff_read_from_str(ctx, "[N] -> { A[] -> [N] }");
+	ma = isl_multi_aff_from_aff_list(space, isl_aff_list_from_aff(aff));
+	isl_multi_aff_free(ma);
+
+	if (!ma)
+		return isl_stat_error;
+	return isl_stat_ok;
+}
+
+/* Perform basic parameter alignment tests.
+ */
+static int test_align_parameters(isl_ctx *ctx)
+{
+	if (test_align_parameters_1(ctx) < 0)
+		return -1;
+	if (test_align_parameters_2(ctx) < 0)
+		return -1;
 
 	return 0;
 }

--- a/isl_test.c
+++ b/isl_test.c
@@ -4763,6 +4763,34 @@ static isl_bool union_pw_aff_plain_is_equal(__isl_keep isl_union_pw_aff *upa,
 	return equal;
 }
 
+/* Basic tests on isl_pw_aff.
+ *
+ * In particular, test the construction of a single-parameter pw_aff from an id.
+ */
+static isl_stat test_pa(isl_ctx *ctx) {
+	isl_id *id;
+	isl_pw_aff *pwa, *pwa2;
+	isl_bool equal;
+
+	id = isl_id_alloc(ctx, "P", NULL);
+	pwa = isl_pw_aff_param_from_id(id);
+	pwa2 = isl_pw_aff_read_from_str(ctx, "[P] -> { [(P)] }");
+
+	equal = isl_pw_aff_plain_is_equal(pwa, pwa2);
+
+	isl_pw_aff_free(pwa);
+	isl_pw_aff_free(pwa2);
+
+	if (equal < 0)
+		return isl_stat_error;
+	if (!equal)
+		isl_die(ctx, isl_error_unknown,
+			"can not construct piecewise aff from id",
+			return isl_stat_error);
+
+	return isl_stat_ok;
+}
+
 /* Check that "upa" is obviously equal to the isl_union_pw_aff
  * represented by "str".
  */
@@ -6048,6 +6076,8 @@ int test_aff(isl_ctx *ctx)
 	isl_aff *aff;
 	int zero, equal;
 
+	if (test_pa(ctx) < 0)
+		return -1;
 	if (test_upa(ctx) < 0)
 		return -1;
 	if (test_bin_aff(ctx) < 0)

--- a/isl_test.c
+++ b/isl_test.c
@@ -4765,10 +4765,12 @@ static isl_bool union_pw_aff_plain_is_equal(__isl_keep isl_union_pw_aff *upa,
 
 /* Basic tests on isl_pw_aff.
  *
- * In particular, test the construction of a single-parameter pw_aff from an id.
+ * In particular, test the construction of a single-parameter pw_aff from an id
+ * or the construction of a zero-parameter pw_aff from an isl val.
  */
 static isl_stat test_pa(isl_ctx *ctx) {
 	isl_id *id;
+	isl_val *val;
 	isl_pw_aff *pwa, *pwa2;
 	isl_bool equal;
 
@@ -4787,6 +4789,23 @@ static isl_stat test_pa(isl_ctx *ctx) {
 		isl_die(ctx, isl_error_unknown,
 			"can not construct piecewise aff from id",
 			return isl_stat_error);
+
+	val = isl_val_int_from_si(ctx, 10);
+	pwa = isl_pw_aff_val_from_val(val);
+	pwa2 = isl_pw_aff_read_from_str(ctx, "{ [(10)] }");
+
+	equal = isl_pw_aff_plain_is_equal(pwa, pwa2);
+
+	isl_pw_aff_free(pwa);
+	isl_pw_aff_free(pwa2);
+
+	if (equal < 0)
+		return isl_stat_error;
+	if (!equal)
+		isl_die(ctx, isl_error_unknown,
+			"can not construct piecewise aff from val",
+			return isl_stat_error);
+
 
 	return isl_stat_ok;
 }

--- a/isl_test.c
+++ b/isl_test.c
@@ -4766,7 +4766,8 @@ static isl_bool union_pw_aff_plain_is_equal(__isl_keep isl_union_pw_aff *upa,
 /* Basic tests on isl_pw_aff.
  *
  * In particular, test the construction of a single-parameter pw_aff from an id
- * or the construction of a zero-parameter pw_aff from an isl val.
+ * or the construction of a zero-parameter pw_aff from an isl val or a signed
+ * integer.
  */
 static isl_stat test_pa(isl_ctx *ctx) {
 	isl_id *id;
@@ -4806,6 +4807,20 @@ static isl_stat test_pa(isl_ctx *ctx) {
 			"can not construct piecewise aff from val",
 			return isl_stat_error);
 
+	pwa = isl_pw_aff_val_from_si(ctx, 10);
+	pwa2 = isl_pw_aff_read_from_str(ctx, "{ [(10)] }");
+
+	equal = isl_pw_aff_plain_is_equal(pwa, pwa2);
+
+	isl_pw_aff_free(pwa);
+	isl_pw_aff_free(pwa2);
+
+	if (equal < 0)
+		return isl_stat_error;
+	if (!equal)
+		isl_die(ctx, isl_error_unknown,
+			"can not construct piecewise aff from signed integer",
+			return isl_stat_error);
 
 	return isl_stat_ok;
 }


### PR DESCRIPTION
This pull request proposes three new functions to simplify the generation of pw_aff expressions on parameter spaces. All expressions are generated on a universe domain.

```
#include <isl/aff.h>                                                     
__isl_give isl_pw_aff *isl_pw_aff_param_from_id(__isl_take isl_id *id);  
__isl_give isl_pw_aff *isl_pw_aff_val_from_val(__isl_take isl_val *val); 
__isl_give isl_pw_aff *isl_pw_aff_val_from_si(__isl_keep isl_ctx *ctx, int val);        
```