### PR TITLE
Construct set and map from parameter set and isl_id lists

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -4687,6 +4687,14 @@ on a given parameter domain using the following functions.
 	__isl_give isl_set *isl_set_from_params(
 		__isl_take isl_set *set);
 
+An n-dimensional set can be constructed from a given parameter set by providing
+a list of isl ids that identify the parameter dimensions which should be
+promoted to set dimensions.
+
+	#include <isl/set.h>
+	__isl_give isl_set *isl_set_from_id_list_params(
+		__isl_take isl_id_list *ids, __isl_take isl_set *set);
+
 =item * Constructing a relation from one or two sets
 
 Create a relation with the given set(s) as domain and/or range.

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -4689,11 +4689,17 @@ on a given parameter domain using the following functions.
 
 An n-dimensional set can be constructed from a given parameter set by providing
 a list of isl ids that identify the parameter dimensions which should be
-promoted to set dimensions.
+promoted to set dimensions. An n+m-dimensional map can be constructed by
+providing two lits of isl ids, the first identifying the new input dimension
+the second the new output dimensions.
 
 	#include <isl/set.h>
 	__isl_give isl_set *isl_set_from_id_list_params(
 		__isl_take isl_id_list *ids, __isl_take isl_set *set);
+	#include <isl/map.h>
+	__isl_give isl_map *isl_map_from_id_list_params(
+		__isl_take isl_id_list *ids_in, __isl_take isl_id_list *ids_out,
+		__isl_take isl_map *map);
 
 =item * Constructing a relation from one or two sets
 

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -509,6 +509,8 @@ __isl_give isl_basic_map *isl_basic_map_from_domain_and_range(
 	__isl_take isl_basic_set *domain, __isl_take isl_basic_set *range);
 __isl_give isl_map *isl_map_from_domain_and_range(__isl_take isl_set *domain,
 	__isl_take isl_set *range);
+__isl_give isl_map *isl_map_from_id_list_params(__isl_take isl_id_list *ids_in,
+	__isl_take isl_id_list *ids_out, __isl_take isl_map *map);
 __isl_export
 __isl_give isl_basic_map *isl_map_sample(__isl_take isl_map *map);
 

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -222,6 +222,8 @@ __isl_give isl_basic_set *isl_basic_set_from_params(
 	__isl_take isl_basic_set *bset);
 __isl_give isl_set *isl_set_params(__isl_take isl_set *set);
 __isl_give isl_set *isl_set_from_params(__isl_take isl_set *set);
+__isl_give isl_set *isl_set_from_id_list_params(__isl_take isl_id_list *ids,
+	__isl_take isl_set *set);
 
 isl_stat isl_basic_set_dims_get_sign(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos, unsigned n, int *signs);

--- a/isl_map.c
+++ b/isl_map.c
@@ -5705,6 +5705,54 @@ __isl_give isl_set *isl_set_from_id_list_params(__isl_take isl_id_list *ids,
 	return set;
 }
 
+/* Construct a map from a map with named parameter dimensions and two list of
+ * ids that indicates the parameter dimensions that should be promoted to map
+ * dimensions.
+ */
+__isl_give isl_map *isl_map_from_id_list_params(__isl_take isl_id_list *ids_in,
+	__isl_take isl_id_list *ids_out, __isl_take isl_map *map)
+{
+	int i;
+
+	if (!map) {
+		isl_id_list_free(ids_in);
+		isl_id_list_free(ids_out);
+		return NULL;
+	}
+
+	if (!ids_in) {
+		isl_id_list_free(ids_out);
+		return isl_map_free(map);
+	}
+
+	if (!ids_out) {
+		isl_id_list_free(ids_in);
+		return isl_map_free(map);
+	}
+
+	for (i = 0; i < isl_id_list_n_id(ids_in); i++) {
+		int p;
+
+		p = isl_map_find_dim_by_id(map, isl_dim_param,
+					   isl_id_list_get_id(ids_in, i));
+		map = isl_map_insert_dims(map, isl_dim_in, i, 1);
+		map = isl_map_equate(map, isl_dim_param, p, isl_dim_in, i);
+		map = isl_map_project_out(map, isl_dim_param, p, 1);
+	}
+
+	for (i = 0; i < isl_id_list_n_id(ids_out); i++) {
+		int p;
+
+		p = isl_map_find_dim_by_id(map, isl_dim_param,
+					   isl_id_list_get_id(ids_out, i));
+		map = isl_map_insert_dims(map, isl_dim_out, i, 1);
+		map = isl_map_equate(map, isl_dim_param, p, isl_dim_out, i);
+		map = isl_map_project_out(map, isl_dim_param, p, 1);
+	}
+
+	return map;
+}
+
 /* Compute the parameter domain of the given map.
  */
 __isl_give isl_set *isl_map_params(__isl_take isl_map *map)

--- a/isl_map.c
+++ b/isl_map.c
@@ -5675,6 +5675,36 @@ __isl_give isl_set *isl_set_from_params(__isl_take isl_set *set)
 	return set;
 }
 
+/* Construct a set from a parameter set with named dimensions and a list of ids
+ * that indicate the parameter dimensions that should be promoted to set
+ * dimensions.
+ */
+__isl_give isl_set *isl_set_from_id_list_params(__isl_take isl_id_list *ids,
+	__isl_take isl_set *set)
+{
+	int i;
+
+	if (!ids)
+		return isl_set_free(set);
+
+	if (!set) {
+		isl_id_list_free(ids);
+		return NULL;
+	}
+
+	for (i = 0; i < isl_id_list_n_id(ids); i++) {
+		int p;
+
+		p = isl_set_find_dim_by_id(set, isl_dim_param,
+					   isl_id_list_get_id(ids, i));
+		set = isl_set_insert_dims(set, isl_dim_set, i, 1);
+		set = isl_set_equate(set, isl_dim_param, p, isl_dim_set, i);
+		set = isl_set_project_out(set, isl_dim_param, p, 1);
+	}
+
+	return set;
+}
+
 /* Compute the parameter domain of the given map.
  */
 __isl_give isl_set *isl_map_params(__isl_take isl_map *map)

--- a/isl_test.c
+++ b/isl_test.c
@@ -644,6 +644,58 @@ static int test_construction_set(isl_ctx *ctx)
 	return 0;
 }
 
+/* Construct the map [p] -> { [i = 10] -> [j = 15, k = 20] } using
+ * isl_map_from_id_list_params. Check that it is equal to the map parsed from a
+ * string.
+ */
+static int test_construction_map_from_id_list_params(isl_ctx *ctx)
+{
+	isl_bool equal;
+	isl_id *id_i, *id_j, *id_k;
+	isl_id_list *idl_in, *idl_out;
+	isl_map *pmap, *map1, *map2;
+
+	pmap = isl_map_read_from_str(ctx,
+		"[p, i, j, k] -> { : i = 10 and j = 15 and k = 20}");
+
+	id_i = isl_id_alloc(ctx, "i", NULL);
+	id_j = isl_id_alloc(ctx, "j", NULL);
+	id_k = isl_id_alloc(ctx, "k", NULL);
+
+	idl_in = isl_id_list_alloc(ctx, 1);
+	idl_in = isl_id_list_insert(idl_in, 0, id_i);
+
+	idl_out = isl_id_list_alloc(ctx, 2);
+	idl_out = isl_id_list_insert(idl_out, 0, id_j);
+	idl_out = isl_id_list_insert(idl_out, 1, id_k);
+
+	map1 = isl_map_from_id_list_params(idl_in, idl_out, pmap);
+
+	map2 = isl_map_read_from_str(ctx,
+		"[p] -> { [i] -> [j, k] : i = 10 and j = 15 and k = 20 }");
+
+	equal = isl_map_is_equal(map1, map2);
+	isl_map_free(map1);
+	isl_map_free(map2);
+
+	if (equal < 0)
+		return -1;
+	if (!equal)
+		isl_die(ctx, isl_error_unknown,
+			"failed construction", return -1);
+
+	return 0;
+}
+
+/* Basic tests for constructing maps.
+ */
+static int test_construction_map(isl_ctx *ctx)
+{
+	if (test_construction_map_from_id_list_params(ctx) < 0)
+		return -1;
+	return 0;
+}
+
 /* Basic tests for constructing isl sets and maps.
  */
 static int test_construction(isl_ctx *ctx)
@@ -651,6 +703,8 @@ static int test_construction(isl_ctx *ctx)
 	if (test_construction_bset(ctx) < 0)
 		return -1;
 	if (test_construction_set(ctx) < 0)
+		return -1;
+	if (test_construction_map(ctx) < 0)
 		return -1;
 	return 0;
 }

--- a/isl_test.c
+++ b/isl_test.c
@@ -587,11 +587,70 @@ static int test_construction_2(isl_ctx *ctx)
 
 /* Basic tests for constructing basic sets.
  */
-static int test_construction(isl_ctx *ctx)
+static int test_construction_bset(isl_ctx *ctx)
 {
 	if (test_construction_1(ctx) < 0)
 		return -1;
 	if (test_construction_2(ctx) < 0)
+		return -1;
+	return 0;
+}
+
+/* Construct the set [p] -> { [i = 10, j = 15] } using
+ * isl_set_from_id_list_params. Check that this set it is equal to the set
+ * parsed from a string.
+ */
+static int test_construction_set_from_id_list_params(isl_ctx *ctx)
+{
+	isl_bool equal;
+	isl_id *id_i, *id_j;
+	isl_id_list *idl;
+	isl_set *pset, *set1, *set2;
+
+	pset = isl_set_read_from_str(ctx,
+		"[p, i, j] -> { : i = 10 and j = 15 }");
+
+	id_i = isl_id_alloc(ctx, "i", NULL);
+	id_j = isl_id_alloc(ctx, "j", NULL);
+
+	idl = isl_id_list_alloc(ctx, 2);
+	idl = isl_id_list_insert(idl, 0, id_i);
+	idl = isl_id_list_insert(idl, 1, id_j);
+
+	set1 = isl_set_from_id_list_params(idl, pset);
+
+	set2 = isl_set_read_from_str(ctx,
+		"[p] -> { [i, j] : i = 10 and j = 15 }");
+
+	equal = isl_set_is_equal(set1, set2);
+	isl_set_free(set1);
+	isl_set_free(set2);
+
+	if (equal < 0)
+		return -1;
+	if (!equal)
+		isl_die(ctx, isl_error_unknown,
+			"failed construction", return -1);
+
+	return 0;
+}
+
+/* Basic tests for constructing sets.
+ */
+static int test_construction_set(isl_ctx *ctx)
+{
+	if (test_construction_set_from_id_list_params(ctx) < 0)
+		return -1;
+	return 0;
+}
+
+/* Basic tests for constructing isl sets and maps.
+ */
+static int test_construction(isl_ctx *ctx)
+{
+	if (test_construction_bset(ctx) < 0)
+		return -1;
+	if (test_construction_set(ctx) < 0)
 		return -1;
 	return 0;
 }


### PR DESCRIPTION
Introduce functions to create a set or map from a parameter set and a list of isl_ids that identify the parameter dimensions that should be promoted to set or map dimensions.